### PR TITLE
V2 changes

### DIFF
--- a/src/main/scala/TpchConfig.scala
+++ b/src/main/scala/TpchConfig.scala
@@ -17,6 +17,7 @@ import org.tpch.pushdown.options.TpchPushdownOptions
  */
 case class Config(
     var start: Int = 0,
+    threadNum: Int = 0,
     testNumbers: String = "",
     var end: Int = -1,
     var currentTest: String = "",
@@ -31,7 +32,9 @@ case class Config(
     checkResults: Boolean = false,
     mode: String = "",  // The mode of the test.
     var format: String = "csv",
+    path: String = "",
     var outputFormat: String = "csv",
+    outputLocation: String = "local", // "hdfs" also valid
     datasource: String = "spark",
     protocol: String = "file",
     var s3HostName: String = "dikehdfs:9858",
@@ -42,9 +45,9 @@ case class Config(
         new TpchPushdownOptions(false, false, false, false, false),
     pushdown: Boolean = false,
     pushUDF: Boolean = false,
-    pushFilter: Boolean = false,
-    pushProject: Boolean = false,
-    pushAggregate: Boolean = false,
+    pushFilter: Boolean = true,
+    pushProject: Boolean = true,
+    pushAggregate: Boolean = true,
     pushRule: Boolean = false,
     debugData: Boolean = false,
     verbose: Boolean = false,
@@ -53,4 +56,5 @@ case class Config(
     normal: Boolean = false,
     metrics: String = "task",
     bytesServer: String = "",
+    sql: Boolean = false,
     kwargs: Map[String, String] = Map())

--- a/src/main/scala/TpchTableReaderHdfs.scala
+++ b/src/main/scala/TpchTableReaderHdfs.scala
@@ -86,6 +86,8 @@ object TpchTableReaderHdfs {
         .option("currenttest", params.config.currentTest)
         .option("ndpcompression", params.config.compression)
         .option("ndpcomplevel", params.config.compLevel)
+        .option((if (params.pushOpt.enableFilter) "ndpenable" else "ndpdisable") + "filterpush", "")
+        .option((if (params.pushOpt.enableAggregate) "ndpenable" else "ndpdisable") + "aggregatepush", "")
         .load(params.inputDir + "/" + name + "." + params.config.format)
     } else if (params.config.format == "parquet") {
       /* Parquet does not use a schema, it gets the schema from the file. */

--- a/tpch.sbt
+++ b/tpch.sbt
@@ -4,8 +4,7 @@ version := "1.0"
 
 scalaVersion := "2.12.10"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % "3.0.1"
-libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.0.1"
 libraryDependencies += "com.github.scopt" %% "scopt" % "4.0.0-RC2"
 libraryDependencies += "org.apache.hadoop" % "hadoop-client" % "3.2.2"
 libraryDependencies += "ch.cern.sparkmeasure" %% "spark-measure" % "0.17"
+libraryDependencies += "org.scala-lang" % "scala-reflect" % "2.12.10"


### PR DESCRIPTION
--mode parallel, which allows multiple tests to be run at the same time.
  We just need to specify the tests comma separated and they will be run
  in parallel.  e.g. -t 14,2
--path option to specify the path of the TPC-H database.
-sql option to run a test using an SQL string instead of a set of dataframe ops.
--outputLocation option to specify where to put the results (hdfs, file).
  This was added to give the ability to put results in hdfs when we
  are generating results in the cluster.